### PR TITLE
Add helm support

### DIFF
--- a/org-redmine.el
+++ b/org-redmine.el
@@ -2,7 +2,7 @@
 
 ;; Author: Wataru MIYAGUNI <gonngo@gmail.com>
 ;; URL: https://github.com/gongo/org-redmine
-;; Package-Requires: ((anything "0"))
+;; Package-Requires: ((anything "0") (helm-core "1.9.1"))
 ;; Keywords: redmine org
 ;; Version: 0.1.0
 
@@ -41,6 +41,7 @@
 (require 'org)
 (require 'json)
 (require 'anything)
+(require 'helm)
 
 (defconst org-redmine-config-default-limit 25
   "Default value the number of items to be present in the response.
@@ -489,6 +490,19 @@ Example.
                  ("Insert Subtree"
                   . (lambda (issue) (org-redmine-insert-subtree issue)))))))
    ))
+
+;;;###autoload
+(defun org-redmine-helm-show-issue-all (&optional me)
+  "Display recent issues using `helm'"
+  (interactive "P")
+  (helm :sources (helm-build-sync-source "Issues"
+                   :candidates (lambda () (org-redmine-get-issue-all me))
+                   :candidate-transformer '(org-redmine-transformer-issues-source)
+                   :volatile t
+                   :action '(("Open Browser"
+                              . (lambda (issue) (browse-url (org-redmine-issue-uri issue))))
+                             ("Insert Subtree"
+                              . (lambda (issue) (org-redmine-insert-subtree issue)))))))
 
 (provide 'org-redmine)
 


### PR DESCRIPTION
Add helm support with `org-redmine-helm-show-issue-all` command.

Fixes #9 
Signed-off-by: Yen-Chin Lee <coldnew.tw@gmail.com>